### PR TITLE
Add OCR of item units

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -77,5 +77,6 @@ flutter {
 }
 
 dependencies {
+    implementation "com.github.yalantis:ucrop:2.2.8"
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.stephentigner.shopping_units">
+   <uses-permission android:name="android.permission.CAMERA" />
+   <uses-feature android:name="android.hardware.camera" />
+   <uses-feature android:name="android.hardware.camera.autofocus" />
    <application
         android:label="Better Buy"
         android:name="${applicationName}"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,1 @@
+platform :ios, '12.0' 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera access is needed to scan product labels for unit measurements</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone access may be needed by the camera system</string>
 	<key>CFBundleDisplayName</key>
 	<string>Shopping Units</string>
 	<key>CFBundleExecutable</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -69,6 +69,9 @@ class _MainScreenState extends State<MainScreen> {
       deletionNoticeTimeoutInSeconds: _deletionNoticeTimeoutInSeconds,
       comparisonListModel: _comparisonListModel,
     );
+    _comparisonListModel.onMeasureTypeChanged = (isFluid) {
+      _toggleMeasureType(isFluid ? 1 : 0);
+    };
     super.initState();
   }
 

--- a/lib/models/comparison_list_model.dart
+++ b/lib/models/comparison_list_model.dart
@@ -30,6 +30,7 @@ class ComparisonListModel with ChangeNotifier {
   List<ComparisonItem> get values => _comparisonItems.values.toList();
 
   void Function()? addComparisonItemCallback;
+  void Function(bool)? onMeasureTypeChanged;
 
   void addComparisonItem(
       int deletionNoticeTimeoutInSeconds,
@@ -40,7 +41,7 @@ class ComparisonListModel with ChangeNotifier {
       deletionNoticeTimeoutInSeconds: deletionNoticeTimeoutInSeconds,
       onItemMarkedDeleted: onItemMarkedDeleted,
       onDeleteItem: onDeleteItem,
-      // onRestoreItem: _restoreItem,
+      onMeasureTypeChanged: onMeasureTypeChanged,
     );
     _comparisonItems[item.details.key] = item;
 

--- a/lib/utils/application_strings.dart
+++ b/lib/utils/application_strings.dart
@@ -25,6 +25,7 @@ class ApplicationStrings {
   static const packageUnitsAmountLabel = "Amount";
   static const multiPackLabel = "Multi-pack";
   static const packageItemCountLabel = "# of Items";
+  static const scanLabelTooltip = "Scan package label for unit measurements";
 
   static const standardizedUnitsLabel = "Compare all items using";
 

--- a/lib/utils/application_strings.dart
+++ b/lib/utils/application_strings.dart
@@ -27,6 +27,8 @@ class ApplicationStrings {
   static const packageItemCountLabel = "# of Items";
   static const scanLabelTooltip = "Scan package label for unit measurements";
   static const cropImageTitle = "Crop Image";
+  static const cropImageDoneButton = "Done";
+  static const cropImageCancelButton = "Cancel";
   static const noMeasurementsFoundError =
       "No unit measurements found in the image";
   static const scanningErrorMessage = "Error scanning label";

--- a/lib/utils/application_strings.dart
+++ b/lib/utils/application_strings.dart
@@ -25,6 +25,16 @@ class ApplicationStrings {
   static const packageUnitsAmountLabel = "Amount";
   static const multiPackLabel = "Multi-pack";
   static const packageItemCountLabel = "# of Items";
+
+  static const standardizedUnitsLabel = "Compare all items using";
+
+  static const deletedItemLabel = "Item deleted";
+  static const restoreItemLabel = "Undo";
+
+  static const currencySymbol = "\$";
+  static const unitPriceLabel = "Unit Price";
+
+  // Scan and crop image
   static const scanLabelTooltip = "Scan package label for unit measurements";
   static const cropImageTitle = "Crop Image";
   static const cropImageDoneButton = "Done";
@@ -40,14 +50,7 @@ class ApplicationStrings {
   static const acceptMeasurementButton = "Use This Measurement";
   static const retryButton = "Try Again";
   static const newPhotoButton = "Take New Photo";
-
-  static const standardizedUnitsLabel = "Compare all items using";
-
-  static const deletedItemLabel = "Item deleted";
-  static const restoreItemLabel = "Undo";
-
-  static const currencySymbol = "\$";
-  static const unitPriceLabel = "Unit Price";
+  static const detectedMeasurementLabel = "Detected measurement: ";
 
   //Menu links
   static const privacyPolicyLink =

--- a/lib/utils/application_strings.dart
+++ b/lib/utils/application_strings.dart
@@ -51,6 +51,8 @@ class ApplicationStrings {
   static const retryButton = "Try Again";
   static const newPhotoButton = "Take New Photo";
   static const detectedMeasurementLabel = "Detected measurement: ";
+  static const noMeasurementsInSelectionMessage =
+      "No measurements found in selected text";
 
   //Menu links
   static const privacyPolicyLink =

--- a/lib/utils/application_strings.dart
+++ b/lib/utils/application_strings.dart
@@ -26,6 +26,12 @@ class ApplicationStrings {
   static const multiPackLabel = "Multi-pack";
   static const packageItemCountLabel = "# of Items";
   static const scanLabelTooltip = "Scan package label for unit measurements";
+  static const cropImageTitle = "Crop Image";
+  static const noMeasurementsFoundError =
+      "No unit measurements found in the image";
+  static const scanningErrorMessage = "Error scanning label";
+  static const cameraDeniedMessage =
+      "Camera permission is required to scan labels";
 
   static const standardizedUnitsLabel = "Compare all items using";
 

--- a/lib/utils/application_strings.dart
+++ b/lib/utils/application_strings.dart
@@ -35,6 +35,12 @@ class ApplicationStrings {
   static const cameraDeniedMessage =
       "Camera permission is required to scan labels";
 
+  // Text Recognition UI
+  static const selectMeasurementTitle = "Select Measurement";
+  static const acceptMeasurementButton = "Use This Measurement";
+  static const retryButton = "Try Again";
+  static const newPhotoButton = "Take New Photo";
+
   static const standardizedUnitsLabel = "Compare all items using";
 
   static const deletedItemLabel = "Item deleted";

--- a/lib/utils/unit_recognition.dart
+++ b/lib/utils/unit_recognition.dart
@@ -16,42 +16,36 @@ class UnitRecognition {
 
   // Map common variations of unit measurements to our UnitType enum
   static final Map<RegExp, UnitType> _unitPatterns = {
-    // Fluid ounces
-    RegExp(r'fl\.?\s*o?z\.?', caseSensitive: false): UnitType.fluidOunces,
-    RegExp(r'fluid\s+o?z\.?', caseSensitive: false): UnitType.fluidOunces,
+    // Fluid ounces - handle OCR misreads of 'O' as '0'
+    RegExp(r'fl\.?\s*[o0]z\.?|fl[o0]z\.?|fluid\s*[o0]z\.?|fluid\s*[o0]unces?',
+        caseSensitive: false): UnitType.fluidOunces,
 
-    // Regular ounces
-    RegExp(r'(?<!fl\.?\s*)o?z\.?(?!\s*fl)', caseSensitive: false):
-        UnitType.ounces,
-    RegExp(r'ounces?(?!\s*fluid)', caseSensitive: false): UnitType.ounces,
+    // Regular ounces - exclude fluid oz and percentages, handle OCR misreads
+    RegExp(r'(?<!fl\.?\s*)(?<!fluid\s*)(?<!%)\s*[o0]z\.?|[o0]unces?(?!\s*fl)',
+        caseSensitive: false): UnitType.ounces,
 
     // Pounds
-    RegExp(r'lb\.?s?', caseSensitive: false): UnitType.pounds,
-    RegExp(r'pounds?', caseSensitive: false): UnitType.pounds,
+    RegExp(r'lb\.?s?|pounds?', caseSensitive: false): UnitType.pounds,
 
-    // Milliliters
-    RegExp(r'ml\.?', caseSensitive: false): UnitType.milliliters,
-    RegExp(r'millili?te?rs?', caseSensitive: false): UnitType.milliliters,
+    // Milliliters - handle parentheses
+    RegExp(r'(?:\(?\s*ml\.?\s*\)?|\(?\s*milliliters?\s*\)?)',
+        caseSensitive: false): UnitType.milliliters,
 
     // Liters
-    RegExp(r'l\.?(?!b)', caseSensitive: false): UnitType.liters,
-    RegExp(r'li?te?rs?', caseSensitive: false): UnitType.liters,
+    RegExp(r'l\.?|liters?', caseSensitive: false): UnitType.liters,
 
     // Milligrams
-    RegExp(r'mg\.?', caseSensitive: false): UnitType.milligrams,
-    RegExp(r'milligrams?', caseSensitive: false): UnitType.milligrams,
+    RegExp(r'mg\.?|milligrams?', caseSensitive: false): UnitType.milligrams,
 
     // Grams
-    RegExp(r'g\.?(?!al)', caseSensitive: false): UnitType.grams,
-    RegExp(r'grams?', caseSensitive: false): UnitType.grams,
+    RegExp(r'g\.?|grams?(?!\w)', caseSensitive: false): UnitType.grams,
 
     // Kilograms
-    RegExp(r'kg\.?', caseSensitive: false): UnitType.kilograms,
-    RegExp(r'kilograms?', caseSensitive: false): UnitType.kilograms,
+    RegExp(r'kg\.?|kilograms?', caseSensitive: false): UnitType.kilograms,
   };
 
-  // Pattern to match a number (including decimals) followed by potential spaces
-  static final _numberPattern = RegExp(r'(\d+\.?\d*)[\s]*');
+  // Simple number pattern that matches integers and decimals
+  static final _numberPattern = RegExp(r'(\d+\.?\d*)');
 
   /// Processes an image file and returns the first recognized unit measurement
   /// Returns null if no valid measurement is found
@@ -83,18 +77,32 @@ class UnitRecognition {
   /// Extracts the first valid measurement from a text string
   /// Returns null if no valid measurement is found
   static UnitMeasurement? _extractMeasurement(String text) {
+    // Add debug logging to see what we're processing
+    developer.log(
+      'Processing text for measurement',
+      name: 'UnitRecognition',
+      error: text,
+    );
+
     // Look for each unit pattern in the text
     for (var entry in _unitPatterns.entries) {
       final unitMatch = entry.key.firstMatch(text);
       if (unitMatch != null) {
-        // Look for a number before the unit
-        final numberMatch = _numberPattern.firstMatch(
-          text.substring(0, unitMatch.start).trim(),
-        );
+        // Search for numbers in the text before the unit
+        final beforeUnit = text.substring(0, unitMatch.start).trim();
 
-        if (numberMatch != null) {
-          final value = double.tryParse(numberMatch.group(1) ?? '');
+        // Find the last number before the unit
+        final numbers = _numberPattern.allMatches(beforeUnit).toList();
+        if (numbers.isNotEmpty) {
+          final lastNumber = numbers.last;
+          final value = double.tryParse(lastNumber.group(1) ?? '');
           if (value != null && value > 0) {
+            // Log successful match
+            developer.log(
+              'Found measurement',
+              name: 'UnitRecognition',
+              error: 'Value: $value, Unit: ${entry.value.abbreviation}',
+            );
             return UnitMeasurement(value, entry.value);
           }
         }

--- a/lib/utils/unit_recognition.dart
+++ b/lib/utils/unit_recognition.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+import 'dart:developer' as developer;
+
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'package:shopping_units/enums/unit_type.dart';
+
+class UnitMeasurement {
+  final double value;
+  final UnitType unit;
+
+  UnitMeasurement(this.value, this.unit);
+}
+
+class UnitRecognition {
+  static final _textRecognizer = TextRecognizer();
+
+  // Map common variations of unit measurements to our UnitType enum
+  static final Map<RegExp, UnitType> _unitPatterns = {
+    // Fluid ounces
+    RegExp(r'fl\.?\s*o?z\.?', caseSensitive: false): UnitType.fluidOunces,
+    RegExp(r'fluid\s+o?z\.?', caseSensitive: false): UnitType.fluidOunces,
+
+    // Regular ounces
+    RegExp(r'(?<!fl\.?\s*)o?z\.?(?!\s*fl)', caseSensitive: false):
+        UnitType.ounces,
+    RegExp(r'ounces?(?!\s*fluid)', caseSensitive: false): UnitType.ounces,
+
+    // Pounds
+    RegExp(r'lb\.?s?', caseSensitive: false): UnitType.pounds,
+    RegExp(r'pounds?', caseSensitive: false): UnitType.pounds,
+
+    // Milliliters
+    RegExp(r'ml\.?', caseSensitive: false): UnitType.milliliters,
+    RegExp(r'millili?te?rs?', caseSensitive: false): UnitType.milliliters,
+
+    // Liters
+    RegExp(r'l\.?(?!b)', caseSensitive: false): UnitType.liters,
+    RegExp(r'li?te?rs?', caseSensitive: false): UnitType.liters,
+
+    // Milligrams
+    RegExp(r'mg\.?', caseSensitive: false): UnitType.milligrams,
+    RegExp(r'milligrams?', caseSensitive: false): UnitType.milligrams,
+
+    // Grams
+    RegExp(r'g\.?(?!al)', caseSensitive: false): UnitType.grams,
+    RegExp(r'grams?', caseSensitive: false): UnitType.grams,
+
+    // Kilograms
+    RegExp(r'kg\.?', caseSensitive: false): UnitType.kilograms,
+    RegExp(r'kilograms?', caseSensitive: false): UnitType.kilograms,
+  };
+
+  // Pattern to match a number (including decimals) followed by potential spaces
+  static final _numberPattern = RegExp(r'(\d+\.?\d*)[\s]*');
+
+  /// Processes an image file and returns the first recognized unit measurement
+  /// Returns null if no valid measurement is found
+  static Future<UnitMeasurement?> recognizeUnits(File imageFile) async {
+    try {
+      final inputImage = InputImage.fromFile(imageFile);
+      final recognizedText = await _textRecognizer.processImage(inputImage);
+
+      // Process each block of text
+      for (TextBlock block in recognizedText.blocks) {
+        for (TextLine line in block.lines) {
+          final measurement = _extractMeasurement(line.text);
+          if (measurement != null) {
+            return measurement;
+          }
+        }
+      }
+    } catch (e) {
+      developer.log(
+        'Error during text recognition',
+        error: e,
+        name: 'UnitRecognition',
+        level: 1000, // Equivalent to severe/error level
+      );
+    }
+    return null;
+  }
+
+  /// Extracts the first valid measurement from a text string
+  /// Returns null if no valid measurement is found
+  static UnitMeasurement? _extractMeasurement(String text) {
+    // Look for each unit pattern in the text
+    for (var entry in _unitPatterns.entries) {
+      final unitMatch = entry.key.firstMatch(text);
+      if (unitMatch != null) {
+        // Look for a number before the unit
+        final numberMatch = _numberPattern.firstMatch(
+          text.substring(0, unitMatch.start).trim(),
+        );
+
+        if (numberMatch != null) {
+          final value = double.tryParse(numberMatch.group(1) ?? '');
+          if (value != null && value > 0) {
+            return UnitMeasurement(value, entry.value);
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Cleans up resources
+  static void dispose() {
+    _textRecognizer.close();
+  }
+}

--- a/lib/utils/unit_recognition.dart
+++ b/lib/utils/unit_recognition.dart
@@ -55,42 +55,9 @@ class UnitRecognition {
   // Simple number pattern that matches integers and decimals
   static final _numberPattern = RegExp(r'(\d+\.?\d*)');
 
-  /// Processes an image file and returns the recognized text blocks and measurement
-  /// Returns null if no valid measurement is found
-  static Future<RecognitionResult> recognizeUnits(File imageFile) async {
-    try {
-      final inputImage = InputImage.fromFile(imageFile);
-      final recognizedText = await _textRecognizer.processImage(inputImage);
-
-      UnitMeasurement? foundMeasurement;
-
-      // Process each block of text
-      for (TextBlock block in recognizedText.blocks) {
-        for (TextLine line in block.lines) {
-          final measurement = _extractMeasurement(line.text, block);
-          if (measurement != null) {
-            foundMeasurement = measurement;
-            break;
-          }
-        }
-        if (foundMeasurement != null) break;
-      }
-
-      return RecognitionResult(recognizedText.blocks, foundMeasurement);
-    } catch (e) {
-      developer.log(
-        'Error during text recognition',
-        error: e,
-        name: 'UnitRecognition',
-        level: 1000, // Equivalent to severe/error level
-      );
-      return RecognitionResult([], null);
-    }
-  }
-
   /// Extracts the first valid measurement from a text string
   /// Returns null if no valid measurement is found
-  static UnitMeasurement? _extractMeasurement(String text, TextBlock block) {
+  static UnitMeasurement? extractMeasurement(String text, [TextBlock? block]) {
     // Add debug logging to see what we're processing
     developer.log(
       'Processing text for measurement',
@@ -123,6 +90,39 @@ class UnitRecognition {
       }
     }
     return null;
+  }
+
+  /// Processes an image file and returns the recognized text blocks and measurement
+  /// Returns null if no valid measurement is found
+  static Future<RecognitionResult> recognizeUnits(File imageFile) async {
+    try {
+      final inputImage = InputImage.fromFile(imageFile);
+      final recognizedText = await _textRecognizer.processImage(inputImage);
+
+      UnitMeasurement? foundMeasurement;
+
+      // Process each block of text
+      for (TextBlock block in recognizedText.blocks) {
+        for (TextLine line in block.lines) {
+          final measurement = extractMeasurement(line.text, block);
+          if (measurement != null) {
+            foundMeasurement = measurement;
+            break;
+          }
+        }
+        if (foundMeasurement != null) break;
+      }
+
+      return RecognitionResult(recognizedText.blocks, foundMeasurement);
+    } catch (e) {
+      developer.log(
+        'Error during text recognition',
+        error: e,
+        name: 'UnitRecognition',
+        level: 1000, // Equivalent to severe/error level
+      );
+      return RecognitionResult([], null);
+    }
   }
 
   /// Cleans up resources

--- a/lib/views/text_recognition_view.dart
+++ b/lib/views/text_recognition_view.dart
@@ -69,7 +69,10 @@ class _TextRecognitionViewState extends State<TextRecognitionView> {
       ),
       body: Column(
         children: [
-          Expanded(
+          // Image container with fixed height
+          SizedBox(
+            height: MediaQuery.of(context).size.height *
+                0.6, // Reduced to 60% of screen height
             child: Stack(
               fit: StackFit.expand,
               children: [
@@ -118,73 +121,93 @@ class _TextRecognitionViewState extends State<TextRecognitionView> {
               ],
             ),
           ),
-          // Measurement preview
-          if (_selectedBlock != null)
-            Container(
-              padding: const EdgeInsets.all(16.0),
-              color: Theme.of(context).colorScheme.surfaceContainerHighest,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  if (_selectedMeasurement != null)
-                    Flexible(
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            ApplicationStrings.detectedMeasurementLabel,
-                            style: Theme.of(context).textTheme.bodyLarge,
-                          ),
-                          Text(
-                            '${_selectedMeasurement!.value} ${_selectedMeasurement!.unit.abbreviation}',
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyLarge
-                                ?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: Theme.of(context).colorScheme.primary,
-                                ),
-                          ),
-                        ],
-                      ),
-                    )
-                  else
-                    Flexible(
-                      child: Text(
-                        ApplicationStrings.noMeasurementsInSelectionMessage,
-                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                              color: Theme.of(context).colorScheme.error,
-                            ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                ],
-              ),
-            ),
-          // Bottom buttons
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Wrap(
-              alignment: WrapAlignment.spaceEvenly,
-              spacing: 8.0,
-              runSpacing: 8.0,
+          // Bottom section
+          Container(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
               children: [
-                TextButton(
-                  onPressed: widget.onRetry,
-                  child: const Text(ApplicationStrings.retryButton),
-                ),
-                TextButton(
-                  onPressed: widget.onNewPhoto,
-                  child: const Text(ApplicationStrings.newPhotoButton),
-                ),
-                if (_selectedBlock != null && _selectedMeasurement != null)
-                  ElevatedButton(
-                    onPressed: () {
-                      widget.onMeasurementSelected(_selectedMeasurement!);
-                    },
-                    child:
-                        const Text(ApplicationStrings.acceptMeasurementButton),
+                // Measurement preview
+                if (_selectedBlock != null)
+                  Container(
+                    padding: const EdgeInsets.all(16.0),
+                    color:
+                        Theme.of(context).colorScheme.surfaceContainerHighest,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        if (_selectedMeasurement != null)
+                          Flexible(
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  ApplicationStrings.detectedMeasurementLabel,
+                                  style: Theme.of(context).textTheme.bodyLarge,
+                                ),
+                                Text(
+                                  '${_selectedMeasurement!.value} ${_selectedMeasurement!.unit.abbreviation}',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .bodyLarge
+                                      ?.copyWith(
+                                        fontWeight: FontWeight.bold,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .primary,
+                                      ),
+                                ),
+                              ],
+                            ),
+                          )
+                        else
+                          Flexible(
+                            child: Text(
+                              ApplicationStrings
+                                  .noMeasurementsInSelectionMessage,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyLarge
+                                  ?.copyWith(
+                                    color: Theme.of(context).colorScheme.error,
+                                  ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                      ],
+                    ),
                   ),
+                // Bottom buttons
+                SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Wrap(
+                      alignment: WrapAlignment.spaceEvenly,
+                      spacing: 8.0,
+                      runSpacing: 8.0,
+                      children: [
+                        TextButton(
+                          onPressed: widget.onRetry,
+                          child: const Text(ApplicationStrings.retryButton),
+                        ),
+                        TextButton(
+                          onPressed: widget.onNewPhoto,
+                          child: const Text(ApplicationStrings.newPhotoButton),
+                        ),
+                        if (_selectedBlock != null &&
+                            _selectedMeasurement != null)
+                          ElevatedButton(
+                            onPressed: () {
+                              widget
+                                  .onMeasurementSelected(_selectedMeasurement!);
+                            },
+                            child: const Text(
+                                ApplicationStrings.acceptMeasurementButton),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/views/text_recognition_view.dart
+++ b/lib/views/text_recognition_view.dart
@@ -27,7 +27,7 @@ class TextRecognitionView extends StatefulWidget {
 
 class _TextRecognitionViewState extends State<TextRecognitionView> {
   TextBlock? _selectedBlock;
-  GlobalKey _imageKey = GlobalKey();
+  final GlobalKey _imageKey = GlobalKey();
   Size? _imageSize;
 
   @override
@@ -40,7 +40,7 @@ class _TextRecognitionViewState extends State<TextRecognitionView> {
 
     // Load image to get its size
     Image image = Image.file(widget.imageFile);
-    image.image.resolve(ImageConfiguration()).addListener(
+    image.image.resolve(const ImageConfiguration()).addListener(
       ImageStreamListener((ImageInfo info, bool _) {
         setState(() {
           _imageSize = Size(
@@ -111,6 +111,29 @@ class _TextRecognitionViewState extends State<TextRecognitionView> {
               ],
             ),
           ),
+          // Measurement preview
+          if (_selectedBlock != null &&
+              widget.recognitionResult.measurement != null)
+            Container(
+              padding: const EdgeInsets.all(16.0),
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    ApplicationStrings.detectedMeasurementLabel,
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                  Text(
+                    '${widget.recognitionResult.measurement!.value} ${widget.recognitionResult.measurement!.unit.abbreviation}',
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                  ),
+                ],
+              ),
+            ),
           // Bottom buttons
           Padding(
             padding: const EdgeInsets.all(16.0),

--- a/lib/views/text_recognition_view.dart
+++ b/lib/views/text_recognition_view.dart
@@ -1,0 +1,239 @@
+import 'dart:io';
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'package:shopping_units/utils/application_strings.dart';
+import 'package:shopping_units/utils/unit_recognition.dart';
+
+class TextRecognitionView extends StatefulWidget {
+  final File imageFile;
+  final RecognitionResult recognitionResult;
+  final Function(UnitMeasurement) onMeasurementSelected;
+  final VoidCallback onRetry;
+  final VoidCallback onNewPhoto;
+
+  const TextRecognitionView({
+    Key? key,
+    required this.imageFile,
+    required this.recognitionResult,
+    required this.onMeasurementSelected,
+    required this.onRetry,
+    required this.onNewPhoto,
+  }) : super(key: key);
+
+  @override
+  State<TextRecognitionView> createState() => _TextRecognitionViewState();
+}
+
+class _TextRecognitionViewState extends State<TextRecognitionView> {
+  TextBlock? _selectedBlock;
+  GlobalKey _imageKey = GlobalKey();
+  Size? _imageSize;
+
+  @override
+  void initState() {
+    super.initState();
+    // If we have a measurement, pre-select its block
+    if (widget.recognitionResult.measurement?.textBlock != null) {
+      _selectedBlock = widget.recognitionResult.measurement!.textBlock;
+    }
+
+    // Load image to get its size
+    Image image = Image.file(widget.imageFile);
+    image.image.resolve(ImageConfiguration()).addListener(
+      ImageStreamListener((ImageInfo info, bool _) {
+        setState(() {
+          _imageSize = Size(
+            info.image.width.toDouble(),
+            info.image.height.toDouble(),
+          );
+        });
+      }),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(ApplicationStrings.selectMeasurementTitle),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                // The image
+                Image.file(
+                  widget.imageFile,
+                  key: _imageKey,
+                  fit: BoxFit.contain,
+                ),
+
+                // Custom overlay with holes for text
+                if (_imageSize != null)
+                  CustomPaint(
+                    painter: TextRegionPainter(
+                      textBlocks: widget.recognitionResult.allBlocks,
+                      selectedBlock: _selectedBlock,
+                      originalImageSize: _imageSize!,
+                      imageKey: _imageKey,
+                    ),
+                    child: Container(),
+                  ),
+
+                // Clickable regions
+                if (_imageSize != null)
+                  ...widget.recognitionResult.allBlocks.map((block) {
+                    final rect = _getScaledRect(block.boundingBox, _imageSize!);
+                    return Positioned(
+                      left: rect.left,
+                      top: rect.top,
+                      width: rect.width,
+                      height: rect.height,
+                      child: GestureDetector(
+                        onTap: () {
+                          setState(() {
+                            _selectedBlock = block;
+                          });
+                        },
+                        child: Container(
+                          decoration: BoxDecoration(
+                            border: block == _selectedBlock
+                                ? Border.all(color: Colors.green, width: 2)
+                                : null,
+                          ),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+              ],
+            ),
+          ),
+          // Bottom buttons
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Wrap(
+              alignment: WrapAlignment.spaceEvenly,
+              spacing: 8.0,
+              runSpacing: 8.0,
+              children: [
+                TextButton(
+                  onPressed: widget.onRetry,
+                  child: const Text(ApplicationStrings.retryButton),
+                ),
+                TextButton(
+                  onPressed: widget.onNewPhoto,
+                  child: const Text(ApplicationStrings.newPhotoButton),
+                ),
+                if (_selectedBlock != null &&
+                    widget.recognitionResult.measurement != null)
+                  ElevatedButton(
+                    onPressed: () {
+                      widget.onMeasurementSelected(
+                          widget.recognitionResult.measurement!);
+                    },
+                    child:
+                        const Text(ApplicationStrings.acceptMeasurementButton),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Rect _getScaledRect(Rect original, Size imageSize) {
+    if (_imageKey.currentContext == null) return original;
+
+    final RenderBox renderBox =
+        _imageKey.currentContext!.findRenderObject() as RenderBox;
+    final Size widgetSize = renderBox.size;
+
+    // Calculate scaling factors
+    double scale = widgetSize.width / imageSize.width;
+    if (imageSize.height * scale > widgetSize.height) {
+      scale = widgetSize.height / imageSize.height;
+    }
+
+    // Calculate offset to center the image
+    double dx = (widgetSize.width - imageSize.width * scale) / 2;
+    double dy = (widgetSize.height - imageSize.height * scale) / 2;
+
+    return Rect.fromLTWH(
+      original.left * scale + dx,
+      original.top * scale + dy,
+      original.width * scale,
+      original.height * scale,
+    );
+  }
+}
+
+class TextRegionPainter extends CustomPainter {
+  final List<TextBlock> textBlocks;
+  final TextBlock? selectedBlock;
+  final Size originalImageSize;
+  final GlobalKey imageKey;
+
+  TextRegionPainter({
+    required this.textBlocks,
+    required this.selectedBlock,
+    required this.originalImageSize,
+    required this.imageKey,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (imageKey.currentContext == null) return;
+    final RenderBox renderBox =
+        imageKey.currentContext!.findRenderObject() as RenderBox;
+    final Size widgetSize = renderBox.size;
+
+    final paint = Paint()
+      ..color = Colors.black.withAlpha(128)
+      ..style = PaintingStyle.fill;
+
+    // Create a path for the entire canvas
+    final backgroundPath = Path()..addRect(Offset.zero & widgetSize);
+
+    // Create a path for all text blocks
+    final holesPath = Path();
+
+    // Calculate scaling factors
+    double scale = widgetSize.width / originalImageSize.width;
+    if (originalImageSize.height * scale > widgetSize.height) {
+      scale = widgetSize.height / originalImageSize.height;
+    }
+
+    // Calculate offset to center the image
+    double dx = (widgetSize.width - originalImageSize.width * scale) / 2;
+    double dy = (widgetSize.height - originalImageSize.height * scale) / 2;
+
+    for (var block in textBlocks) {
+      final Rect scaledRect = Rect.fromLTWH(
+        block.boundingBox.left * scale + dx,
+        block.boundingBox.top * scale + dy,
+        block.boundingBox.width * scale,
+        block.boundingBox.height * scale,
+      );
+      holesPath.addRect(scaledRect);
+    }
+
+    // Cut out the holes from the background
+    final finalPath = Path.combine(
+      PathOperation.difference,
+      backgroundPath,
+      holesPath,
+    );
+
+    canvas.drawPath(finalPath, paint);
+  }
+
+  @override
+  bool shouldRepaint(TextRegionPainter oldDelegate) {
+    return oldDelegate.selectedBlock != selectedBlock ||
+        oldDelegate.textBlocks != textBlocks;
+  }
+}

--- a/lib/widgets/comparison_item.dart
+++ b/lib/widgets/comparison_item.dart
@@ -33,12 +33,14 @@ class ComparisonItem extends StatefulWidget {
   final int deletionNoticeTimeoutInSeconds;
   final void Function(ItemDetails)? onItemMarkedDeleted;
   final void Function(ItemDetails)? onDeleteItem;
+  final void Function(bool)? onMeasureTypeChanged;
 
   ComparisonItem({
     Key? key,
     required this.deletionNoticeTimeoutInSeconds,
     this.onItemMarkedDeleted,
     this.onDeleteItem,
+    this.onMeasureTypeChanged,
   }) : super(key: key);
 
   @override
@@ -211,12 +213,12 @@ class _ComparisonItemState extends State<ComparisonItem> {
             await UnitRecognition.recognizeUnits(File(image.path));
 
         if (measurement != null) {
-          setState(() {
-            // Update isFluidMeasure if needed
-            if (_details.isFluidMeasure != measurement.unit.isFluidMeasure) {
-              _details.isFluidMeasure = measurement.unit.isFluidMeasure;
-            }
+          // Update global fluid/solid state if needed
+          if (_details.isFluidMeasure != measurement.unit.isFluidMeasure) {
+            widget.onMeasureTypeChanged?.call(measurement.unit.isFluidMeasure);
+          }
 
+          setState(() {
             // Update the amount and units
             _details.packageUnitsAmount = measurement.value;
             _details.packageUnits = measurement.unit;

--- a/lib/widgets/comparison_item.dart
+++ b/lib/widgets/comparison_item.dart
@@ -256,50 +256,6 @@ class _ComparisonItemState extends State<ComparisonItem> {
                   onMeasurementSelected: (measurement) {
                     Navigator.pop(context, measurement);
                   },
-                  onRetry: () async {
-                    final BuildContext currentContext = context;
-                    Navigator.pop(currentContext);
-                    // Reprocess the same cropped image
-                    final newResult = await UnitRecognition.recognizeUnits(
-                        File(croppedFile.path));
-
-                    if (!currentContext.mounted) return;
-
-                    if (newResult.measurement != null) {
-                      final result = await Navigator.push<UnitMeasurement>(
-                        currentContext,
-                        MaterialPageRoute(
-                          builder: (context) => TextRecognitionView(
-                            imageFile: File(croppedFile.path),
-                            recognitionResult: newResult,
-                            onMeasurementSelected: (measurement) {
-                              Navigator.pop(context, measurement);
-                            },
-                            onRetry: () async {
-                              Navigator.pop(context);
-                              await _scanLabel();
-                            },
-                            onNewPhoto: () {
-                              Navigator.pop(context);
-                              _scanLabel();
-                            },
-                          ),
-                        ),
-                      );
-                      if (result != null && currentContext.mounted) {
-                        Navigator.pop(currentContext, result);
-                      }
-                    } else {
-                      if (currentContext.mounted) {
-                        ScaffoldMessenger.of(currentContext).showSnackBar(
-                          const SnackBar(
-                            content: Text(
-                                ApplicationStrings.noMeasurementsFoundError),
-                          ),
-                        );
-                      }
-                    }
-                  },
                   onNewPhoto: () {
                     Navigator.pop(context);
                     _scanLabel();

--- a/lib/widgets/comparison_item.dart
+++ b/lib/widgets/comparison_item.dart
@@ -223,13 +223,17 @@ class _ComparisonItemState extends State<ComparisonItem> {
           uiSettings: [
             AndroidUiSettings(
               toolbarTitle: ApplicationStrings.cropImageTitle,
-              toolbarColor: Theme.of(context).primaryColor,
-              toolbarWidgetColor: Theme.of(context).colorScheme.onPrimary,
+              toolbarColor: Theme.of(context).colorScheme.surface,
+              toolbarWidgetColor: Theme.of(context).colorScheme.onSurface,
+              activeControlsWidgetColor: Theme.of(context).colorScheme.primary,
               initAspectRatio: CropAspectRatioPreset.original,
               lockAspectRatio: false,
+              statusBarColor: Theme.of(context).colorScheme.surface,
             ),
             IOSUiSettings(
               title: ApplicationStrings.cropImageTitle,
+              doneButtonTitle: ApplicationStrings.cropImageDoneButton,
+              cancelButtonTitle: ApplicationStrings.cropImageCancelButton,
             ),
           ],
         );

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -105,6 +113,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+2"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -126,6 +166,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "615a505aef59b151b46bbeef55b36ce2b6ed299d160c51d84281946f0aa0ce0e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.24"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -152,6 +200,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   image:
     dependency: transitive
     description:
@@ -160,6 +224,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "82652a75e3dd667a91187769a6a2cc81bd8c111bbead698d8e938d2b63e5e89a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+21"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   json_annotation:
     dependency: transitive
     description:
@@ -224,6 +352,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -232,6 +368,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.4.0"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f84a188e79a35c687c132a0a0556c254747a08561e99ab933f12f6ca71ef3c98
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.6"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:
@@ -430,5 +614,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -224,6 +224,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  image_cropper:
+    dependency: "direct main"
+    description:
+      name: image_cropper
+      sha256: f4bad5ed2dfff5a7ce0dfbad545b46a945c702bb6182a921488ef01ba7693111
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
+  image_cropper_for_web:
+    dependency: transitive
+    description:
+      name: image_cropper_for_web
+      sha256: "865d798b5c9d826f1185b32e5d0018c4183ddb77b7b82a931e1a06aa3b74974e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  image_cropper_platform_interface:
+    dependency: transitive
+    description:
+      name: image_cropper_platform_interface
+      sha256: ee160d686422272aa306125f3b6fb1c1894d9b87a5e20ed33fa008e7285da11e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   image_picker:
     dependency: "direct main"
     description:
@@ -288,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -136,6 +136,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  google_mlkit_commons:
+    dependency: transitive
+    description:
+      name: google_mlkit_commons
+      sha256: "046586b381cdd139f7f6a05ad6998f7e339d061bd70158249907358394b5f496"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.1"
+  google_mlkit_text_recognition:
+    dependency: "direct main"
+    description:
+      name: google_mlkit_text_recognition
+      sha256: d484de2a10961a6f0ff8b54cc92b71bfbb0e65509be0903edca0e1f9256ca4c2
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.0"
   image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   flutter:
     sdk: flutter
   google_mlkit_text_recognition: ^0.11.0
+  image_picker: ^1.0.7
+  permission_handler: ^11.3.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   google_mlkit_text_recognition: ^0.11.0
   image_picker: ^1.0.7
   permission_handler: ^11.3.0
+  image_cropper: ^5.0.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
+  google_mlkit_text_recognition: ^0.11.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
+  permission_handler_windows
   url_launcher_windows
 )
 


### PR DESCRIPTION
This pull request adds a new feature that allows the user to take a photo of the item and extract the units from it instead of typing them in.

Included in this new feature:
* Ability to crop the scanned image before processing
* Preview of detected text regions with the first detected units auto-selected
* Ability to select a different region if the first detected one was incorrect
* Preview of detected measurement text in selected region (if any)
* Ability to try again by reprocessing the same image
* Ability to try again with a different image